### PR TITLE
added missing purrr reference to set_names call

### DIFF
--- a/R/cdc_growth.R
+++ b/R/cdc_growth.R
@@ -1,9 +1,10 @@
-
-#' Title
+#' create_cdc_growth
 #'
-#' @param data Input data.frame.
+#' Calculate important maternal child health measures from a dataset
+#' @param df Input data.frame.
 #'
-#' @return
+#' @return the original data frame with percentiles, z-scores, and related values
+#' added as additional columns
 #' @export
 #'
 #' @references Cole TJ, Bellizzi MC, Flegal KM, Dietz WH. Establishing a
@@ -12,6 +13,8 @@
 #' @references https://www.cdc.gov/nccdphp/dnpao/growthcharts/resources/sas.htm
 #'
 #' @examples
+#' ## NHANES example data is included with package
+#' create_cdc_growth(nhanes_data)
 create_cdc_growth <- function(df) {
   # prepare data
   prepped_data <- mchtoolbox:::cdcgrowth_prep(df)

--- a/R/cdc_growth.R
+++ b/R/cdc_growth.R
@@ -114,7 +114,7 @@ compute_cdc_growth <- function(df)  {
     dplyr::bind_cols(df, .)
 
   final_df <- purrr::map_dfc(
-    .x = set_names(z_vars, p_vars), # pass z to p_fun and name them with p_vars
+    .x = purrr::set_names(z_vars, p_vars), # pass z to p_fun and name them with p_vars
     .f = p_fun,
     df = data_zscores
   ) %>%

--- a/man/create_cdc_growth.Rd
+++ b/man/create_cdc_growth.Rd
@@ -2,15 +2,23 @@
 % Please edit documentation in R/cdc_growth.R
 \name{create_cdc_growth}
 \alias{create_cdc_growth}
-\title{Title}
+\title{create_cdc_growth}
 \usage{
 create_cdc_growth(df)
 }
 \arguments{
-\item{data}{Input data.frame.}
+\item{df}{Input data.frame.}
+}
+\value{
+the original data frame with percentiles, z-scores, and related values
+added as additional columns
 }
 \description{
-Title
+Calculate important maternal child health measures from a dataset
+}
+\examples{
+## NHANES example data is included with package
+create_cdc_growth(nhanes_data)
 }
 \references{
 Cole TJ, Bellizzi MC, Flegal KM, Dietz WH. Establishing a


### PR DESCRIPTION
hey,
i've been busily checking out the runconf18 packages and trying out the demos.
when i ran `create_cdc_growth(nhanes_data)` i got an error `Error in set_names(z_vars, p_vars) : could not find function "set_names" ` 🌻 i made a small change to one of the lines in the `compute_cdc_growth()` function which was missing `purrr::` before the `set_names()` call and then tried to follow Hadley's 🧙‍♂️ [guide to pull requests ](http://r-pkgs.had.co.nz/git.html#git-pullreq). 
Hopefully i have got it all right and have not blown anything up.
Also added a commit to remove some warnings on the docs for `create_cdc_growth()`