### PR TITLE
Use DT for rendering data table in shiny app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,8 +21,9 @@ Imports:
     dplyr,
     readr,
     shinythemes,
-    rlang
-RoxygenNote: 6.0.1
+    rlang,
+    DT
+RoxygenNote: 6.1.0
 URL: https://github.com/ropenscilabs/mchtoolbox
 BugReports: https://github.com/ropenscilabs/mchtoolbox/issues
 Suggests: 

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -31,13 +31,7 @@ shinyServer(function(input, output, session) {
       stop(safeError(e))
     })
 
-    if (input$disp == "head") {
-      return(head(df))
-    }
-    else {
-      return(df)
-    }
-
+    return(df)
   })
 
 

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -4,10 +4,11 @@ library("ggplot2")
 library("mchtoolbox")
 library("dplyr")
 library("viridisLite")
+library("DT")
 
 shinyServer(function(input, output, session) {
 
-  output$contents <- renderTable({
+  output$contents <- renderDT({
     # input$file1 will be NULL initially. After the user selects
     # and uploads a file, head of that data file by default,
     # or all rows if selected, will be shown.

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -4,6 +4,7 @@ library("ggplot2")
 library("mchtoolbox")
 library("dplyr")
 library("viridisLite")
+library("DT")
 
 shinyUI(
   navbarPage(
@@ -100,8 +101,8 @@ shinyUI(
                #textOutput("selected_var")
         )
       ),
-      #DTOutput('results_out')
-      tableOutput("contents"),
+      DTOutput('contents'),
+      #tableOutput("contents"),
 
       br()
     ),

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -60,20 +60,7 @@ shinyUI(
             "Single Quote" = "'"
           ),
           selected = '"'
-        ),
-
-        # Horizontal line ----
-        tags$hr(),
-
-        # Input: Select number of rows to display ----
-        radioButtons(
-          "disp",
-          "Display",
-          choices = c(Head = "head",
-                      All = "all"),
-          selected = "head"
         )
-
       ),
       br(),
       fluidRow(


### PR DESCRIPTION
I really like this project and hope it can be widely used in the community!  This PR swaps out the `renderTable` method of displaying the data results with `DT::renderDT` in the shiny app. I've had great success in using `DT` for my shiny apps in the enterprise and I think it offers a more user-friendly way for the user to interact with data than the typical display of all data without sorting or paging capabilities.  There is a lot more we can do in terms of options for the display (such as column filtering, etc) and I'd be glad to amend this PR if you are interested in exploring those.